### PR TITLE
Upgrade pyscopg 2->3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
             django,
             django-stubs,
             dj_database_url,
-            psycopg2,
+            'psycopg[binary]',
             django-extensions,
             django-crispy-forms,
             crispy-bootstrap5,

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ django-stubs-ext==0.8.0
 gunicorn==20.1.0
 jinja2==3.1.1
 lxml==4.9.1
-psycopg2==2.9.1
+psycopg[binary]==3.1.8
 pyyaml==6.0
 requests==2.28.1
 text-unidecode==1.3


### PR DESCRIPTION
Seems needed for python 3.11 support (#231).